### PR TITLE
[bsp][tricore] Add support for rtt auto initialization

### DIFF
--- a/TC264/Lcf_Tasking_Tricore_Tc.lsl
+++ b/TC264/Lcf_Tasking_Tricore_Tc.lsl
@@ -433,6 +433,16 @@ derivative tc26
 		"_A8_DATA_" := sizeof(group:a8) > 0 ? addressof(group:a8) + 32k : addressof(group:a8) & 0xF0000000 + 32k;
 		"_A8_MEM" := "_A8_DATA_";
 	}
+
+    /*RT-Thread Code Section*/
+    section_layout :vtc:linear
+    {
+        group rt_thread_section (ordered, contiguous, align = 4, run_addr=mem:pfls0)
+        {
+            /* section information for RT-Thread auto initial. */
+            select  ".rti_fn.*";
+        }       
+    }
 	
 	section_layout :vtc:abs18
 	{

--- a/TC364/Lcf_Tasking_Tricore_Tc.lsl
+++ b/TC364/Lcf_Tasking_Tricore_Tc.lsl
@@ -746,6 +746,15 @@ derivative tc36
                     select "(.text.text_cpu1|.text.text_cpu1.*)";
                 }
             }
+            /*RT-Thread Code Section*/
+            group
+            {
+                group rt_thread_section (ordered, contiguous, align = 4, run_addr=mem:pfls0)
+                {
+                    /* section information for RT-Thread auto initial. */
+                    select  ".rti_fn.*";
+                }
+            }            
         }
         
         /*Code Sections, selectable by toolchain*/

--- a/TC377/Lcf_Tasking_Tricore_Tc.lsl
+++ b/TC377/Lcf_Tasking_Tricore_Tc.lsl
@@ -922,6 +922,15 @@ derivative tc37
                     select "(.text.text_cpu2|.text.text_cpu2.*)";
                 }
             }
+            /*RT-Thread Code Section*/
+            group
+            {
+                group rt_thread_section (ordered, contiguous, align = 4, run_addr=mem:pfls0)
+                {
+                    /* section information for RT-Thread auto initial. */
+                    select  ".rti_fn.*";
+                }
+            }              
         }
         
         /*Code Sections, selectable by toolchain*/


### PR DESCRIPTION
在 LSL 文件中添加对 .rti_fn section 的选择，用于 rtt 的自动初始化

PS: TC264 的 LSL文件使用 tab 进行缩进，下次修改为空格